### PR TITLE
Fix main filename in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "lemonade",
     "version": "2",
-    "main": "css/lemonade.min.css",
+    "main": "css/lemonade.css",
     "author": "Joe Richardson",
     "ignore": [
         "README.md",


### PR DESCRIPTION
`main` file name was invalid in `bower.json`.
